### PR TITLE
Add Railtie

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in heroku_deploy.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HerokuDeploy
 
-Logic to deploy to heroku in the FTW way.
+Logic to deploy to Heroku in the FTW way.
 
 It's a bit hacky and def doesn't take care of all edge cases and possible
 error conditions, but the first step is getting it in a gem so diff
@@ -9,12 +9,12 @@ projects can share it, so we can make improvements worthwhile.
 * checks to see if migrations need to be run, runs them if so, with maintenance
   mode and restart.
 * Tries some other sanity checks, including try to ensure your code has been
-  pushed to origin before you can deploy it to heroku.
+  pushed to origin before you can deploy it to Heroku.
 
-1. Add the gem to Gemfile
+1. Add the gem to Gemfile.
 
         group :development do
-           gem 'heroku_deploy', git: "git@github.com:friendsoftheweb/heroku_deploy.git"
+           gem "heroku_deploy", git: "git@github.com:friendsoftheweb/heroku_deploy.git"
         end
 
 2. Add task to your `Rakefile` if you are not using Rails.
@@ -25,7 +25,7 @@ projects can share it, so we can make improvements worthwhile.
     apps might have different config params, and this is one way to
     provide for that.
 
-3. Make sure you have a heroku remote in your git checkout
+3. Make sure you have a Heroku remote in your git checkout.
 
 4. Call the rake task with remote name:
 
@@ -39,7 +39,7 @@ projects can share it, so we can make improvements worthwhile.
 
 * Rewrite all that bash in plain ruby to be less hairy?
 
-* Should this be in the gemfile or at all, or just a generic
+* Should this be in the Gemfile or at all, or just a generic
   utility you have installed on your machine? What if it needs
   project-specific config? Look in current directory for a `.deploy-config`
   file or something?  Would it be bad that an app can't insist on

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ projects can share it, so we can make improvements worthwhile.
            gem 'heroku_deploy', git: "git@github.com:friendsoftheweb/heroku_deploy.git"
         end
 
-2. Add task to your `Rakefile`
+2. Add task to your `Rakefile` if you are not using Rails.
 
         HerokuDeploy::Task.new
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require "rake/testtask"
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList['test/**/*_test.rb']
+  t.test_files = FileList["test/**/*_test.rb"]
 end
 
 task :default => :test

--- a/heroku_deploy.gemspec
+++ b/heroku_deploy.gemspec
@@ -1,22 +1,22 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'heroku_deploy/version'
+require "heroku_deploy/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "heroku_deploy"
   spec.version       = HerokuDeploy::VERSION
   spec.authors       = ["Friends of the Web"]
-  spec.email         = ["infon@friendsoftheweb.com"]
+  spec.email         = ["info@friendsoftheweb.com"]
 
   spec.summary       = %q{heroku deployment the way FTW wants it}
   spec.homepage      = "http://github.com/friendsoftheweb/heroku_deploy"
   spec.license       = "MIT"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
+  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the "allowed_push_host"
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "http://nosuchhost"
+    spec.metadata["allowed_push_host"] = "http://nosuchhost"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."

--- a/lib/heroku_deploy.rb
+++ b/lib/heroku_deploy.rb
@@ -1,7 +1,7 @@
 require "heroku_deploy/version"
-require 'heroku_deploy/task'
+require "heroku_deploy/task"
 require "heroku_deploy/railtie" if defined?(Rails)
 
 module HerokuDeploy
-  DEPLOY_SCRIPT_PATH = File.expand_path File.join(__FILE__, '../../scripts/deploy.sh')
+  DEPLOY_SCRIPT_PATH = File.expand_path File.join(__FILE__, "../../scripts/deploy.sh")
 end

--- a/lib/heroku_deploy.rb
+++ b/lib/heroku_deploy.rb
@@ -1,5 +1,7 @@
 require "heroku_deploy/version"
 require 'heroku_deploy/task'
+require "heroku_deploy/railtie" if defined?(Rails)
+
 module HerokuDeploy
   DEPLOY_SCRIPT_PATH = File.expand_path File.join(__FILE__, '../../scripts/deploy.sh')
 end

--- a/lib/heroku_deploy/railtie.rb
+++ b/lib/heroku_deploy/railtie.rb
@@ -1,0 +1,7 @@
+module HerokuDeploy
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      HerokuDeploy::Task.new
+    end
+  end
+end

--- a/lib/heroku_deploy/task.rb
+++ b/lib/heroku_deploy/task.rb
@@ -1,4 +1,4 @@
-require 'pp'
+require "pp"
 
 module HerokuDeploy
   class Task
@@ -20,9 +20,9 @@ module HerokuDeploy
           exit 1
         end
 
-        system_call = [HerokuDeploy::DEPLOY_SCRIPT_PATH, remote_name, '2>&1']
+        system_call = [HerokuDeploy::DEPLOY_SCRIPT_PATH, remote_name, "2>&1"]
 
-        $stderr.puts system_call.join(' ')
+        $stderr.puts system_call.join(" ")
 
         success = system *system_call
 

--- a/lib/heroku_deploy/version.rb
+++ b/lib/heroku_deploy/version.rb
@@ -1,3 +1,3 @@
 module HerokuDeploy
-  VERSION = "0.1.0"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Script can be automatically run within a Rails project without modifying the `Rakefile`. Also bumps the version to 1 to reflect usage in production environments.